### PR TITLE
Allow for additional common IDS

### DIFF
--- a/config.py
+++ b/config.py
@@ -96,7 +96,8 @@ df_a =  {
         },
         # Map each standard match variable listed below to the *preprocessed*
         # variable name. If a match variable is not included in your data, delete
-        # the key-value pair for it.
+        # the key-value pair for it. Make sure to add any comparison variables 
+        # to the sim_param below
         'vars' :{
             ### ID that represents an individual in this dataset
             'indv_id': '',
@@ -183,7 +184,8 @@ df_b =  {
         },
         # Map each standard match variable listed below to the *preprocessed*
         # variable name. If a match variable is not included in your data, delete
-        # the key-value pair for it.
+        # the key-value pair for it.Make sure to add any comparison variables 
+        # to the sim_param below
         'vars' :{
             ### ID that represents an individual in this dataset
             'indv_id': '',
@@ -248,6 +250,11 @@ ground_truth_ids = []
 # the two variables to invert (e.g. xf_inv, xl_inv)
 # - If you want to skip a pass in the default blocking strategy, leave
 # the list for that pass as empty brackets.
+# - If you want to use the same acceptance logic for multiple blocks,
+# name each block with the number of that block logic and a sublabel (for
+# example 1a and 1b to run two blocks using the acceptance logic for block 1)
+# - Be sure to add comparison variables for any additional blocks in the section
+# below
 blocks_by_pass = {
     "0": ['common_id', 'fname', 'lname', 'byear', 'bmonth', 'bday'], # pass 0
     "1": ['common_id'], # pass 1

--- a/config.py
+++ b/config.py
@@ -245,16 +245,20 @@ ground_truth_ids = []
 
 ### Blocking strategy ---------------------------------------------------------
 
-# Lists of blocking variables by blocking pass
+# Mapping of blocking pass to blocking variables
+# - Format with the blocking pass as the key and the blocking variables as values
 # - For any inverted blocking passes, add '_inv' to the end of each of
-# the two variables to invert (e.g. xf_inv, xl_inv)
+#   the two variables to invert (e.g. xf_inv, xl_inv)
 # - If you want to skip a pass in the default blocking strategy, leave
-# the list for that pass as empty brackets.
-# - If you want to use the same acceptance logic for multiple blocks,
-# name each block with the number of that block logic and a sublabel (for
-# example 1a and 1b to run two blocks using the acceptance logic for block 1)
+#   the list for that pass as empty brackets.
+# - Each blocking pass is mapped to an acceptance logic function based on the 
+#   pass number, as defined in `shared/record_linkage_shared/accept_functions.py`.  
+#   To apply the same acceptance logic function to multiple blocking passes,  
+#   assign those passes the same pass number with a unique sublabel  
+#   (e.g., blocking passes '1a' and '1b' will use the `accept_p1_<strictness>` 
+#    function in `accept_functions.py`).  
 # - Be sure to add comparison variables for any additional blocks in the section
-# below
+#   below
 blocks_by_pass = {
     "0": ['common_id', 'fname', 'lname', 'byear', 'bmonth', 'bday'], # pass 0
     "1": ['common_id'], # pass 1
@@ -265,7 +269,8 @@ blocks_by_pass = {
 
 ### Comparison variables and similarity measures  -----------------------------
 
-# Lists of comparison names by blocking pass
+# Mapping of blocking pass to comparison names
+# Format with the blocking pass as the key and the comparison variables as values
 # These comparison names will have corresponding similarity measurements defined
 # in sim_param below.
 comp_names_by_pass = {

--- a/config.py
+++ b/config.py
@@ -248,32 +248,32 @@ ground_truth_ids = []
 # the two variables to invert (e.g. xf_inv, xl_inv)
 # - If you want to skip a pass in the default blocking strategy, leave
 # the list for that pass as empty brackets.
-blocks_by_pass = [
-    ['common_id', 'fname', 'lname', 'byear', 'bmonth', 'bday'], # pass 0
-    ['common_id'], # pass 1
-    ['xf', 'xl'] , # pass 2
-    ['xf_inv', 'xl_inv'] , # pass 3, inverted soundex
-    ['byear', 'bmonth', 'bday'] # pass 4
-]
+blocks_by_pass = {
+    "0": ['common_id', 'fname', 'lname', 'byear', 'bmonth', 'bday'], # pass 0
+    "1": ['common_id'], # pass 1
+    "2": ['xf', 'xl'] , # pass 2
+    "3": ['xf_inv', 'xl_inv'] , # pass 3, inverted soundex
+    "4": ['byear', 'bmonth', 'bday'] # pass 4
+}
 
 ### Comparison variables and similarity measures  -----------------------------
 
 # Lists of comparison names by blocking pass
 # These comparison names will have corresponding similarity measurements defined
 # in sim_param below.
-comp_names_by_pass = [
-  [], # pass 0, N/A
-  ['fname', 'mname', 'lname', 'altlname',
+comp_names_by_pass = {
+  "0": [], # pass 0, N/A
+  "1": ['fname', 'mname', 'lname', 'altlname',
       'bmonthbday', 'byear', 'fnamelname', 'lnamefname'], # pass 1
-  ['fname', 'mname', 'lname', 'altlname',
+  "2": ['fname', 'mname', 'lname', 'altlname',
       'bmonthbday', 'byear', 'common_id', 'minitial',
       'zipcode', 'county'] , # pass 2
-  ['fnamelname', 'mname', 'lnamefname', 'altlname',
+  "3": ['fnamelname', 'mname', 'lnamefname', 'altlname',
       'bmonthbday', 'byear', 'common_id', 'minitial',
       'zipcode', 'county'] , # pass 3
-  ['fname', 'mname', 'lname', 'altlname',
+  "4": ['fname', 'mname', 'lname', 'altlname',
    'common_id', 'minitial', 'zipcode', 'county'] # pass 4
-]
+}
 
 # Parameters for similarity measures corresponding to each comparison name
 # listed in comp_names_by_pass above. See match_helpers.prepare_comparers()

--- a/config.py
+++ b/config.py
@@ -102,6 +102,9 @@ df_a =  {
             'indv_id': '',
             ### Comparison variables
             # ID that is shared with the other dataset (e.g. SSN, student ID)
+            # To add multiple common_ids, use "common_id" as the prefix for all, followed
+            # by whatever name wanted to differentiate the ids (e.g. common_id_ssn). 
+            # Ensure mapped name aligns between both df_a and df_b
             'common_id': '',
             # Name components
             'fname': '',
@@ -186,6 +189,9 @@ df_b =  {
             'indv_id': '',
             ### Comparison variables
             # ID that is shared with the other dataset (e.g. SSN, student ID)
+            # To add multiple common_ids, use "common_id" as the prefix for all, followed
+            # by whatever name wanted to differentiate the ids (e.g. common_id_ssn). 
+            # Ensure mapped name aligns between both df_a and df_b
             'common_id': '',
             # Name components
             'fname': '',

--- a/shared/record_linkage_shared/accept.py
+++ b/shared/record_linkage_shared/accept.py
@@ -8,6 +8,7 @@ comments preceding each code section below.
 
 '''
 import os
+import re
 import json
 import sys
 
@@ -40,7 +41,7 @@ def accept_matches(df_match, passnum, config):
 
     Input:
         - df_match: output dataframe from match.py, incl. pair indices and scores
-        - passnum: the pass number
+        - passnum (str): the current pass
         - config (dict)
 
     Returns the dataframe with four additional boolean columns:
@@ -120,9 +121,11 @@ def accept_matches(df_match, passnum, config):
 
     ##### Evaluate and accept -------------------------------------------------
     this_pass = df_match.passnum == passnum
+    p_numeric = int(re.sub(r'\D+', '', passnum))
     accepted_in_prev_strictness = False
+
     for strictness in ('strict', 'moderate', 'relaxed', "review"):
-        accept_fn = getattr(accept_functions, f"accept_p{passnum}_{strictness}")
+        accept_fn = getattr(accept_functions, f"accept_p{p_numeric}_{strictness}")
         df_match.loc[this_pass, f"match_{strictness}"] = accept_fn(df_match,
                                                                    masks,
                                                                    thresholds) | \

--- a/shared/record_linkage_shared/accept.py
+++ b/shared/record_linkage_shared/accept.py
@@ -66,14 +66,15 @@ def accept_matches(df_match, passnum, config):
 
     # create filters for high-similarity common_id so that it will skip
     # if the match does not compare common_id similarities
-    if 'common_id' in df_match.columns:
-        masks['common_id_null'] = df_match.common_id == -1
-        masks['id_high_mask'] = df_match.common_id >= thresholds['id_high_score']
-        masks['id_review_mask'] = df_match.common_id >= id_review_score
-    else:
-        masks['common_id_null'] = True
-        masks['id_high_mask'] = False
-        masks['id_review_mask'] = False
+    common_id_fields = [x for x in df_match.columns if "common_id" in x]
+    masks['common_id_null'] = len(common_id_fields) == 0
+    masks['id_high_mask'] = False
+    masks['id_review_mask'] = False
+
+    for common_id in common_id_fields:
+        masks['common_id_null'] = masks['common_id_null'] | (df_match[common_id] == -1)
+        masks['id_high_mask'] = masks['id_high_mask'] | (df_match[common_id] >= thresholds['id_high_score'])
+        masks['id_review_mask'] = masks['id_review_mask'] | (df_match[common_id] >= id_review_score)
 
     # mname filters
     if 'minitial' in df_match.columns:

--- a/shared/record_linkage_shared/accept.py
+++ b/shared/record_linkage_shared/accept.py
@@ -73,6 +73,7 @@ def accept_matches(df_match, passnum, config):
     masks['id_review_mask'] = False
 
     for common_id in common_id_fields:
+        # Note: If any ID is null, the common_id_null mask is applied
         masks['common_id_null'] = masks['common_id_null'] | (df_match[common_id] == -1)
         masks['id_high_mask'] = masks['id_high_mask'] | (df_match[common_id] >= thresholds['id_high_score'])
         masks['id_review_mask'] = masks['id_review_mask'] | (df_match[common_id] >= id_review_score)

--- a/shared/record_linkage_shared/match_functions.py
+++ b/shared/record_linkage_shared/match_functions.py
@@ -180,8 +180,8 @@ def run_match_parallelized(df_a, df_b, vars_a, vars_b, name_a, name_b,
     output_vars = ["indv_id_a", "indv_id_b", "idx_a", "idx_b",
                    "passnum", "match_strict", "match_moderate",
                    "match_relaxed", "match_review", "weight"]
-    for comp_vars in config["comp_names_by_pass"]:
-        for var in config["comp_names_by_pass"][comp_vars]:
+    for comp_vars in config['comp_names_by_pass'].values():
+        for var in comp_vars:
             if var not in output_vars:
                 output_vars.append(var)
 

--- a/shared/record_linkage_shared/match_functions.py
+++ b/shared/record_linkage_shared/match_functions.py
@@ -9,6 +9,7 @@ Helper functions for match.py, including:
 '''
 import time
 import gc
+import re
 import os
 import csv
 import glob
@@ -180,16 +181,17 @@ def run_match_parallelized(df_a, df_b, vars_a, vars_b, name_a, name_b,
                    "passnum", "match_strict", "match_moderate",
                    "match_relaxed", "match_review", "weight"]
     for comp_vars in config["comp_names_by_pass"]:
-        for var in comp_vars:
+        for var in config["comp_names_by_pass"][comp_vars]:
             if var not in output_vars:
                 output_vars.append(var)
 
     # Run match in parallel
     all_cands = []
-    tot_pass_cnt = len(config['blocks_by_pass'])
+    passes =  sorted(config['blocks_by_pass'])
     last_time = time.time()
     i = 0
-    for passnum in range(tot_pass_cnt):
+    for passnum in passes:
+        p_numeric = int(re.sub(r'\W+', '', passnum))
         # Complete blocking for pass
         past_join_cond_str  = block_functions.run_blocking_pass(
                                                 config["blocks_by_pass"],
@@ -216,7 +218,7 @@ def run_match_parallelized(df_a, df_b, vars_a, vars_b, name_a, name_b,
                 cmd = f"SELECT indv_id_a, indv_id_b, idx_a, idx_b FROM {schema}.{cand_table}"
                 cur.execute(cmd)
                 # Read in block by chunks, running similiarity check once threshold hit
-                while chunk := cur.fetchmany(size=chunk_sizes[str(passnum)]):
+                while chunk := cur.fetchmany(size=chunk_sizes[passnum]):
                     if not chunk:
                         break
                     candidates = pd.DataFrame(chunk,
@@ -227,7 +229,7 @@ def run_match_parallelized(df_a, df_b, vars_a, vars_b, name_a, name_b,
                         dfs = process_pool.starmap(run_match, tuple(all_cands))
                         dfs = pd.concat(dfs, ignore_index=True)
                         counts = calculate_pass_match_counts(dfs, counts)
-                        calculate_weights(dfs, tot_pass_cnt)
+                        calculate_weights(dfs, len(passes))
                         # Save out sorted dataframe to temp file
                         dfs = dfs.sort_values("weight", ascending=False)
                         dfs.reindex(columns=output_vars).to_csv(f"temp_match_{i}.csv",
@@ -249,7 +251,7 @@ def run_match_parallelized(df_a, df_b, vars_a, vars_b, name_a, name_b,
                 dfs = process_pool.starmap(run_match, tuple(all_cands))
                 dfs = pd.concat(dfs, ignore_index=True)
                 counts = calculate_pass_match_counts(dfs, counts)
-                calculate_weights(dfs, tot_pass_cnt)
+                calculate_weights(dfs, len(passes))
                 # Save out sorted dataframe to temp file
                 dfs = dfs.sort_values("weight", ascending=False)
                 dfs.reindex(columns=output_vars).to_csv(f"temp_match_{i}.csv",
@@ -262,7 +264,7 @@ def run_match_parallelized(df_a, df_b, vars_a, vars_b, name_a, name_b,
         dfs = process_pool.starmap(run_match, tuple(all_cands))
         dfs = pd.concat(dfs, ignore_index=True)
         counts = calculate_pass_match_counts(dfs, counts)
-        calculate_weights(dfs, tot_pass_cnt)
+        calculate_weights(dfs, len(passes))
         dfs = dfs.sort_values("weight", ascending=False)
         dfs.reindex(columns=output_vars).to_csv(f"temp_match_{i}.csv", index=False)
         all_cands = []
@@ -289,7 +291,7 @@ def run_match_for_candidate_set(candidates, passnum, df_a, df_b, df_sim,
 
     Inputs:
         - candidates: (pandas Dataframe) dataframe of indexes to compare
-        - passnum: (int) current pass
+        - passnum: (str) the current pass
         - df_a, df_b: (pandas Dataframe) original datasets to compare
         - df_sim: (pandas Dataframe) dataset to store results
         - std_varnames: (list) standardized variable names in input data
@@ -298,8 +300,10 @@ def run_match_for_candidate_set(candidates, passnum, df_a, df_b, df_sim,
 
     Returns updated df_sim
     '''
+    p_numeric = int(re.sub(r'\D+', '', passnum))
+
     # Find matching candidates for this pass based on blocking variables
-    if (passnum == 0) & (len(config['comp_names_by_pass'][0]) == 0):
+    if (p_numeric == 0) & (len(config['comp_names_by_pass'][passnum]) == 0):
         # All candidates are exact matches, no comparison needed
         matches = candidates
         matches['passnum'] = passnum
@@ -371,7 +375,7 @@ def prepare_comparers(vars_a, vars_b, config):
     '''
     sim_param = config['sim_param']
     # get all comparison variables
-    all_comp_names = set(itertools.chain(*config['comp_names_by_pass']))
+    all_comp_names = set(itertools.chain(*config['comp_names_by_pass'].values()))
     valid_comp_names = get_valid_comp_names(std_varnames=list(vars_a))
     comps = {}
     for cn in all_comp_names:
@@ -472,7 +476,7 @@ def calc_similarities(df_a, df_b, passnum, candidates, comp_names, comps):
 
     Input:
         - df_a, df_b: (pandas DataFrame) input data
-        - passnum: (int) pass number for this pass
+        - passnum: (str) the current pass
         - candidates: (pandas MultiIndex) pairs of indices of match candidates,
             returned by find_candidates function
         - comp_names: (list of str) list of comparison names/labels for this
@@ -663,14 +667,20 @@ def calculate_weights(dfs, tot_pass_cnt):
         dfs (dataframe): match results
         tot_pass_cnt (int): total number of passes
     '''
-    eval_string = f"10 ** ({tot_pass_cnt} - passnum) + " + \
+    dfs["p_numeric"] = dfs.apply(lambda x: int(re.sub(r'\D+', '', x.passnum)),
+                                 axis=1)
+    eval_string = f"10 ** ({tot_pass_cnt} - p_numeric) + " + \
                   " + ".join(dfs.drop(columns=["indv_id_a",
                                                "indv_id_b",
                                                "idx_a", "idx_b",
-                                               "passnum"]))
+                                               "match_strict", "match_moderate",
+                                               "match_relaxed", "match_review",
+                                               "passnum", "p_numeric"]))
+
     # Replace negative scores (ie missing values) with .5 to avoid
     # negatively impacting weights
     dfs["weight"] = dfs.replace(-1, .5).fillna(0).eval(eval_string)
+    dfs.drop(columns=["p_numeric"], inplace=True)
 
 
 def print_runtime(last_time):
@@ -691,12 +701,14 @@ def print_match_count(counts, passnum=None):
     if passnum is None:
         p_mask = counts.passnum.notnull()
         sums = counts[p_mask].fillna(0).groupby(["strictness"]
-                                                ).agg({'match': "sum"}).reset_index()
+                                                ).agg({'match': "sum"}
+                                                      ).reset_index()
         print('=== All Passes ===')
     else:
         p_mask = counts.passnum == passnum
         sums = counts[p_mask].fillna(0).groupby(["passnum",
-                                                 "strictness"]).sum().reset_index()
+                                                 "strictness"]
+                                                ).sum().reset_index()
         if str(passnum).startswith('dup'):
             print('=== Ground truth ID {} ==='.format(passnum[4:]))
         else:


### PR DESCRIPTION
This merge request adds the option to include more than one common ID. To do this, one would label each common ID `common_id_<descriptor>` and update the blocks/comparisons accordingly. The additional common ID logic is incorporated in two parts:
- The blocks
    - Additional blocks can be added now that use the same match logic as one of the previously defined blocks. To do so, the block should have the number of the acceptance logic to use (such as 1 for the case of common ID), followed by some descriptor to distinguish the blocks (no numbers included). 
    - To make this work, passnum is now a string instead of an integer, and regex expressions are used to pull the pass number when needed (primarily for the acceptance criteria to use and the weighting). I thought about renaming the variable to passname, but it was getting hard to track. Let me know if how it looks now makes sense.
- The match logic
    - In `accept.py`, a for-loop over the common_ids creates the common_id related masks (`common_id_null`, `id_high_mask`, `id_review_mask`).
    - If any ID is not null, then `common_id_null`  is false
    - If any ID is above the threshold for the masks, then the respective mask is true

I added some documentation, but please review it and let me know if it makes sense/I missed places to add information.